### PR TITLE
Fix Undefined variable $places in states/IN.php

### DIFF
--- a/trunk/states/IN.php
+++ b/trunk/states/IN.php
@@ -52,4 +52,4 @@ $states['IN'] = array(
 );
 
 // Use this filter to handle the States and union territories of India
-$places['IN'] = apply_filters('scpwoo_custom_places_in', $places['IN']);
+$states['IN'] = apply_filters('scpwoo_custom_places_in', $places['IN']);

--- a/trunk/states/IN.php
+++ b/trunk/states/IN.php
@@ -52,4 +52,4 @@ $states['IN'] = array(
 );
 
 // Use this filter to handle the States and union territories of India
-$states['IN'] = apply_filters('scpwoo_custom_places_in', $places['IN']);
+$states['IN'] = apply_filters('scpwoo_custom_places_in', $states['IN']);


### PR DESCRIPTION
A warning was thrown about an undefined `$places` variable inside `states/IN.php`.
This variable should've been `$states` instead, which was defined earlier in the file.

```
Warning: Undefined variable $places in \app\public\wp-content\plugins\woocommerce_states_places-master\states\IN.php on line 55

Warning: Trying to access array offset on value of type null in \app\public\wp-content\plugins\woocommerce_states_places-master\states\IN.php on line 55
```